### PR TITLE
change(salsa20): refactor quarterround, rowround and columnround

### DIFF
--- a/src/salsa20/columnround.lean
+++ b/src/salsa20/columnround.lean
@@ -2,71 +2,46 @@
   Section 5 : The columnrow function
   http://cr.yp.to/snuffle/spec.pdf
 -/
+import data.matrix.basic
+
 import salsa20.words
 import salsa20.quarterround
+import salsa20.rowround
 
 open words
 open quarterround
+open rowround
 
 namespace columnround
 
--- (y₀, y₄, y₈, y₁₂) = quarterround(x₀, x₄, x₈, x₁₂)
-def columnround1 (x₀ x₄ x₈ x₁₂ : bitvec word_len) : vector (bitvec word_len) 4 := 
-  quarterround (subtype.mk [x₀, x₄, x₈, x₁₂] (by refl))
+-- Given a 4x4 matrix convert it to a vector of 16 word bitvects.
+def matrix_as_vector (Y : matrix (fin 4) (fin 4) (bitvec word_len)) : vector (bitvec word_len) 16 :=
+  subtype.mk [
+    Y 0 0, Y 0 1, Y 0 2, Y 0 3,
+    Y 1 0, Y 1 1, Y 1 2, Y 1 3,
+    Y 2 0, Y 2 1, Y 2 2, Y 2 3,
+    Y 3 0, Y 3 1, Y 3 2, Y 3 3
+  ] (by refl)
 
--- (y₅, y₉, y₁₃, y₁) = quarterround(x₅, x₉, x₁₃, x₁)
-def columnround2 (x₅ x₉ x₁₃ x₁ : bitvec word_len) : vector (bitvec word_len) 4 := 
-  quarterround (subtype.mk [x₅, x₉, x₁₃, x₁] (by refl))
+-- The columnround function defined as the transpose of the rowround
+def columnround (y : vector(bitvec word_len) 16) : matrix (fin 4) (fin 4) (bitvec word_len) := do
+  -- transpose the input
+  let Y := (vector_as_matrix y).transpose,
+  -- apply rowround and transpose the result
+  (rowround (matrix_as_vector Y)).transpose
 
--- (y₁₀, y₁₄, y₂, y₆) = quarterround(x₁₀, x₁₄, x₂, x₆)
-def columnround3 (x₁₀ x₁₄ x₂ x₆ : bitvec word_len) : vector (bitvec word_len) 4 := 
-  quarterround (subtype.mk [x₁₀, x₁₄, x₂, x₆] (by refl))
-
--- (y₁₅, y₃, y₇, y₁₁) = quarterround(x₁₅, x₃, x₇, x₁₁)
-def columnround4 (x₁₅ x₃ x₇ x₁₁ : bitvec word_len) : vector (bitvec word_len) 4 := 
-  quarterround (subtype.mk [x₁₅, x₃, x₇, x₁₁] (by refl))
-
--- If x = (x₀, x₁, x₂, x₃, ... , x₁₅) then 
--- columnround(x) = (y₀, y₁, y₂, y₃, ... , y₁₅) where
--- (y₀, y₄, y₈, y₁₂) = quarterround(x₀, x₄, x₈, x₁₂)
--- (y₅, y₉, y₁₃, y₁) = quarterround(x₅, x₉, x₁₃, x₁)
--- (y₁₀, y₁₄, y₂, y₆) = quarterround(x₁₀, x₁₄, x₂, x₆)
--- (y₁₅, y₃, y₇, y₁₁) = quarterround(x₁₅, x₃, x₇, x₁₁)
-def columnround
-  (x : vector (bitvec word_len) 16) : vector (bitvec word_len) 16 :=
-  do
-    let c1 := columnround1 (x.nth 0) (x.nth 4) (x.nth 8) (x.nth 12),
-    let c2 := columnround2 (x.nth 5) (x.nth 9) (x.nth 13) (x.nth 1),
-    let c3 := columnround3 (x.nth 10) (x.nth 14) (x.nth 2) (x.nth 6),
-    let c4 := columnround4 (x.nth 15) (x.nth 3) (x.nth 7) (x.nth 11),
-
-    let y₀ := c1.head,
-    let y₄ := c1.nth 1,
-    let y₈ := c1.nth 2,
-    let y₁₂ := c1.nth 3,
-
-    let y₅ := c2.head,
-    let y₉ := c2.nth 1,
-    let y₁₃ := c2.nth 2,
-    let y₁ := c2.nth 3,
-
-    let y₁₀ := c3.head,
-    let y₁₄ := c3.nth 1,
-    let y₂ := c3.nth 2,
-    let y₆ := c3.nth 3,
-
-    let y₁₅ := c4.head,
-    let y₃ := c4.nth 1,
-    let y₇ := c4.nth 2,
-    let y₁₁ := c4.nth 3,
-
-    subtype.mk [y₀, y₁, y₂, y₃, y₄, y₅, y₆, y₇, y₈, y₉, y₁₀, y₁₁, y₁₂, y₁₃, y₁₄, y₁₅] (by refl)
-
+-- The columnround of input all zeros is a matrix where its componenets are all zeros.
 lemma columnround_zero : 
   columnround (subtype.mk [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] (by refl)) = 
-    subtype.mk [0, 0, 0 ,0, 0, 0, 0, 0, 0, 0, 0, 0 ,0 ,0, 0, 0] (by refl) := rfl
+    ![
+     ![0, 0, 0 ,0],
+     ![0, 0, 0 ,0],
+     ![0, 0, 0 ,0],
+     ![0, 0, 0 ,0]
+    ] :=
+    begin
+      exact dec_trivial,
+    end
 
--- TODO: equivalent formula
--- TODO: matrix form
 
 end columnround

--- a/src/salsa20/doubleround.lean
+++ b/src/salsa20/doubleround.lean
@@ -16,10 +16,11 @@ namespace doubleround
 -- rowround(columnround(x))
 def doubleround(x : vector (bitvec word_len) 16) : vector (bitvec word_len) 16 := do
   let y := columnround x,
-  rowround y
+  matrix_as_vector (rowround (matrix_as_vector y))
 
 lemma doubleround_zero : 
   doubleround (subtype.mk [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] (by refl)) = 
     subtype.mk [0, 0, 0 ,0, 0, 0, 0, 0, 0, 0, 0, 0 ,0 ,0, 0, 0] (by refl) := rfl
+
 
 end doubleround

--- a/src/salsa20/examples.lean
+++ b/src/salsa20/examples.lean
@@ -115,11 +115,6 @@ namespace example1
 def y : (vector (bitvec word_len) 4) := 
   subtype.mk [0x00000000, 0x00000000, 0x00000000, 0x00000000] (by refl)
 
-example : (z₁ y).to_nat = 0x00000000 := by refl
-example : (z₂ y).to_nat = 0x00000000 := by refl
-example : (z₃ y).to_nat = 0x00000000 := by refl
-example : (z₀ y).to_nat = 0x00000000 := by refl
-
 end example1
 
 -- example 2
@@ -128,19 +123,15 @@ namespace example2
 def y : (vector (bitvec word_len) 4) := 
   subtype.mk [0x00000001, 0x00000000, 0x00000000, 0x00000000] (by refl)
 
-#eval (z₁ y).to_nat
 #eval 0x00000080
 #eval ((quarterround y).nth 1).to_nat
 
-#eval (z₂ y).to_nat
 #eval 0x00010200
 #eval ((quarterround y).nth 2).to_nat
 
-#eval (z₃ y).to_nat
 #eval 0x20500000
 #eval ((quarterround y).nth 3).to_nat
 
-#eval (z₀ y).to_nat
 #eval 0x08008145
 #eval ((quarterround y).nth 0).to_nat
 
@@ -152,19 +143,15 @@ namespace example3
 def y : (vector (bitvec word_len) 4) := 
   subtype.mk [0x00000000, 0x00000001, 0x00000000, 0x00000000] (by refl)
 
-#eval (z₁ y).to_nat
 #eval 0x00000001
 #eval ((quarterround y).nth 1).to_nat
 
-#eval (z₂ y).to_nat
 #eval 0x00000200
 #eval ((quarterround y).nth 2).to_nat
 
-#eval (z₃ y).to_nat
 #eval 0x00402000
 #eval ((quarterround y).nth 3).to_nat
 
-#eval (z₀ y).to_nat
 #eval 0x88000100
 #eval ((quarterround y).head).to_nat
 
@@ -181,19 +168,15 @@ def y3 : bitvec word_len := 0x00000000
 def y : (vector (bitvec word_len) 4) := 
   subtype.mk [0x00000000, 0x00000000, 0x00000001, 0x00000000] (by refl)
 
-#eval (z₁ y).to_nat
 #eval 0x00000000
 #eval ((quarterround y).nth 1).to_nat
 
-#eval (z₂ y).to_nat
 #eval 0x00000001
 #eval ((quarterround y).nth 2).to_nat
 
-#eval (z₃ y).to_nat
 #eval 0x00002000
 #eval ((quarterround y).nth 3).to_nat
 
-#eval (z₀ y).to_nat
 #eval 0x80040000
 #eval ((quarterround y).head).to_nat
 
@@ -205,19 +188,15 @@ namespace example5
 def y : (vector (bitvec word_len) 4) := 
   subtype.mk [0x00000000, 0x00000000, 0x00000000, 0x00000001] (by refl)
 
-#eval (z₁ y).to_nat
 #eval 0x00000080
 #eval ((quarterround y).nth 1).to_nat
 
-#eval (z₂ y).to_nat
 #eval 0x00010000
 #eval ((quarterround y).nth 2).to_nat
 
-#eval (z₃ y).to_nat
 #eval 0x20100001
 #eval ((quarterround y).nth 3).to_nat
 
-#eval (z₀ y).to_nat
 #eval 0x00048044
 #eval ((quarterround y).head).to_nat
 
@@ -229,19 +208,15 @@ namespace example6
 def y : (vector (bitvec word_len) 4) := 
   subtype.mk [0xe7e8c006, 0xc4f9417d, 0x6479b4b2, 0x68c67137] (by refl)
 
-#eval (z₁ y).to_nat
 #eval 0x9361dfd5
 #eval ((quarterround y).nth 1).to_nat
 
-#eval (z₂ y).to_nat
 #eval 0xf1460244
 #eval ((quarterround y).nth 2).to_nat
 
-#eval (z₃ y).to_nat
 #eval 0x948541a3
 #eval ((quarterround y).nth 3).to_nat
 
-#eval (z₀ y).to_nat
 #eval 0xe876d72b
 #eval ((quarterround y).head).to_nat
 
@@ -253,19 +228,15 @@ namespace example7
 def y : (vector (bitvec word_len) 4) := 
   subtype.mk [0xd3917c5b, 0x55f1c407, 0x52a58a7a, 0x8f887a3b] (by refl)
 
-#eval (z₁ y).to_nat
 #eval 0xd90a8f36
 #eval ((quarterround y).nth 1).to_nat
 
-#eval (z₂ y).to_nat
 #eval 0x6ab2a923
 #eval ((quarterround y).nth 2).to_nat
 
-#eval (z₃ y).to_nat
 #eval 0x2883524c
 #eval ((quarterround y).nth 3).to_nat
 
-#eval (z₀ y).to_nat
 #eval 0x3e2f308c
 #eval ((quarterround y).head).to_nat
 
@@ -278,17 +249,16 @@ def y : (vector (bitvec word_len) 4) :=
   subtype.mk [0xe7e8c006, 0xc4f9417d, 0x6479b4b2, 0x68c67137] (by refl)
 
 #eval (y.nth 0).to_nat
-#eval (y₀ (quarterround y)).to_nat
+#eval ((quarterround_inv (quarterround y)).nth 0).to_nat
 
 #eval (y.nth 3).to_nat
-#eval (y₃ (quarterround y)).to_nat
+#eval ((quarterround_inv (quarterround y)).nth 3).to_nat
 
 #eval (y.nth 2).to_nat
-#eval (y₂ (quarterround y)).to_nat
+#eval ((quarterround_inv (quarterround y)).nth 2).to_nat
 
 #eval (y.nth 1).to_nat
-#eval (y₁ (quarterround y)).to_nat
-
+#eval ((quarterround_inv (quarterround y)).nth 1).to_nat
 
 end inverse1
 
@@ -304,15 +274,19 @@ def y : (vector (bitvec word_len) 4) :=
 def z (y : vector (bitvec word_len) 4) : vector (bitvec word_len) 4 := quarterround y
 
 #eval ((quarterround_inv (z y)).nth 0).to_nat
+#eval ((quarterround_inv (quarterround y)).nth 0).to_nat
 
 #eval (y.nth 1).to_nat
 #eval ((quarterround_inv (z y)).nth 1).to_nat
+#eval ((quarterround_inv (quarterround y)).nth 1).to_nat
 
 #eval (y.nth 2).to_nat
 #eval ((quarterround_inv (z y)).nth 2).to_nat
+#eval ((quarterround_inv (quarterround y)).nth 2).to_nat
 
 #eval (y.nth 3).to_nat
 #eval ((quarterround_inv (z y)).nth 3).to_nat
+#eval ((quarterround_inv (quarterround y)).nth 3).to_nat
 
 
 end inverse2
@@ -346,68 +320,68 @@ def y : vector (bitvec word_len) 16 :=
   subtype.mk [y₀, y₁, y₂, y₃, y₄, y₅, y₆, y₇, y₈, y₉, y₁₀, y₁₁, y₁₂, y₁₃, y₁₄, y₁₅] (by refl)
 
 -- z₀
-#eval ((rowround y).nth 0).to_nat
 #eval 0x08008145
+#eval ((rowround y) 0 0).to_nat
 
 -- z₁
-#eval ((rowround y).nth 1).to_nat
 #eval 0x00000080
+#eval ((rowround y) 0 1).to_nat
 
 -- z₂
-#eval ((rowround y).nth 2).to_nat
 #eval 0x00010200
+#eval ((rowround y) 0 2).to_nat
 
 -- z₃
-#eval ((rowround y).nth 3).to_nat
 #eval 0x20500000
+#eval ((rowround y) 0 3).to_nat
 
 -- z₄
-#eval ((rowround y).nth 4).to_nat
 #eval 0x20100001
+#eval ((rowround y) 1 0).to_nat
 
 -- z₅
-#eval ((rowround y).nth 5).to_nat
 #eval 0x00048044
+#eval ((rowround y) 1 1).to_nat
 
 -- z₆
-#eval ((rowround y).nth 6).to_nat
 #eval 0x00000080
+#eval ((rowround y) 1 2).to_nat
 
 -- z₇
-#eval ((rowround y).nth 7).to_nat
 #eval 0x00010000
+#eval ((rowround y) 1 3).to_nat
 
 -- z₈
-#eval ((rowround y).nth 8).to_nat
 #eval 0x00000001
+#eval ((rowround y) 2 0).to_nat
 
 -- z₉
-#eval ((rowround y).nth 9).to_nat
 #eval 0x00002000
+#eval ((rowround y) 2 1).to_nat
 
 -- z₁₀
-#eval ((rowround y).nth 10).to_nat
 #eval 0x80040000
+#eval ((rowround y) 2 2).to_nat
 
 -- z₁₁
-#eval ((rowround y).nth 11).to_nat
 #eval 0x00000000
+#eval ((rowround y) 2 3).to_nat
 
 -- z₁₂
-#eval ((rowround y).nth 12).to_nat
 #eval 0x00000001
+#eval ((rowround y) 3 0).to_nat
 
 -- z₁₃
-#eval ((rowround y).nth 13).to_nat
 #eval 0x00000200
+#eval ((rowround y) 3 1).to_nat
 
 -- z₁₄
-#eval ((rowround y).nth 14).to_nat
 #eval 0x00402000
+#eval ((rowround y) 3 2).to_nat
 
 -- z₁₅
-#eval ((rowround y).nth 15).to_nat
 #eval 0x88000100
+#eval ((rowround y) 3 3).to_nat
 
 end example1
 
@@ -435,68 +409,68 @@ def y : vector (bitvec word_len) 16 :=
   subtype.mk [y₀, y₁, y₂, y₃, y₄, y₅, y₆, y₇, y₈, y₉, y₁₀, y₁₁, y₁₂, y₁₃, y₁₄, y₁₅] (by refl)
 
 -- z₀
-#eval ((rowround y).nth 0).to_nat
 #eval 0xa890d39d
+#eval ((rowround y) 0 0).to_nat
 
 -- z₁
-#eval ((rowround y).nth 1).to_nat
 #eval 0x65d71596
+#eval ((rowround y) 0 1).to_nat
 
 -- z₂
-#eval ((rowround y).nth 2).to_nat
 #eval 0xe9487daa
+#eval ((rowround y) 0 2).to_nat
 
 -- z₃
-#eval ((rowround y).nth 3).to_nat
 #eval 0xc8ca6a86
+#eval ((rowround y) 0 3).to_nat
 
 -- z₄
-#eval ((rowround y).nth 4).to_nat
 #eval 0x949d2192
+#eval ((rowround y) 1 0).to_nat
 
 -- z₅
-#eval ((rowround y).nth 5).to_nat
 #eval 0x764b7754
+#eval ((rowround y) 1 1).to_nat
 
 -- z₆
-#eval ((rowround y).nth 6).to_nat
 #eval 0xe408d9b9
+#eval ((rowround y) 1 2).to_nat
 
 -- z₇
-#eval ((rowround y).nth 7).to_nat
 #eval 0x7a41b4d1
+#eval ((rowround y) 1 3).to_nat
 
 -- z₈
-#eval ((rowround y).nth 8).to_nat
 #eval 0x3402e183
+#eval ((rowround y) 2 0).to_nat
 
 -- z₉
-#eval ((rowround y).nth 9).to_nat
 #eval 0x3c3af432
+#eval ((rowround y) 2 1).to_nat
 
 -- z₁₀
-#eval ((rowround y).nth 10).to_nat
 #eval 0x50669f96
+#eval ((rowround y) 2 2).to_nat
 
 -- z₁₁
-#eval ((rowround y).nth 11).to_nat
 #eval 0xd89ef0a8
+#eval ((rowround y) 2 3).to_nat
 
 -- z₁₂
-#eval ((rowround y).nth 12).to_nat
 #eval 0x0040ede5
+#eval ((rowround y) 3 0).to_nat
 
 -- z₁₃
-#eval ((rowround y).nth 13).to_nat
 #eval 0xb545fbce
+#eval ((rowround y) 3 1).to_nat
 
 -- z₁₄
-#eval ((rowround y).nth 14).to_nat
 #eval 0xd257ed4f
+#eval ((rowround y) 3 2).to_nat
 
 -- z₁₅
-#eval ((rowround y).nth 15).to_nat
 #eval 0x1818882d
+#eval ((rowround y) 3 3).to_nat
 
 end example2
 
@@ -504,7 +478,7 @@ end example2
 end rowround 
 
 
-namespace rowround
+namespace columnround
 
 -- example 1
 namespace example1
@@ -530,68 +504,68 @@ def x : vector (bitvec word_len) 16 :=
   subtype.mk [x₀, x₁, x₂, x₃, x₄, x₅, x₆, x₇, x₈, x₉, x₁₀, x₁₁, x₁₂, x₁₃, x₁₄, x₁₅] (by refl)
 
 -- y₀
-#eval ((columnround x).nth 0).to_nat
 #eval 0x10090288
+#eval ((columnround x) 0 0).to_nat
 
 -- y₁
-#eval ((columnround x).nth 1).to_nat
 #eval 0x00000000
+#eval ((columnround x) 0 1).to_nat
 
 -- y₂
-#eval ((columnround x).nth 2).to_nat
 #eval 0x00000000
+#eval ((columnround x) 0 2).to_nat
 
 -- y₃
-#eval ((columnround x).nth 3).to_nat
 #eval 0x00000000
+#eval ((columnround x) 0 3).to_nat
 
 -- y₄
-#eval ((columnround x).nth 4).to_nat
 #eval 0x00000101
+#eval ((columnround x) 1 0).to_nat
 
 -- y₅
-#eval ((columnround x).nth 5).to_nat
 #eval 0x00000000
+#eval ((columnround x) 1 1).to_nat
 
 -- y₆
-#eval ((columnround x).nth 6).to_nat
 #eval 0x00000000
+#eval ((columnround x) 1 2).to_nat
 
 -- y₇
-#eval ((columnround x).nth 7).to_nat
 #eval 0x00000000
+#eval ((columnround x) 1 3).to_nat
 
 -- y₈
-#eval ((columnround x).nth 8).to_nat
 #eval 0x00020401
+#eval ((columnround x) 2 0).to_nat
 
 -- y₉
-#eval ((columnround x).nth 9).to_nat
 #eval 0x00000000
+#eval ((columnround x) 2 1).to_nat
 
 -- y₁₀
-#eval ((columnround x).nth 10).to_nat
 #eval 0x00000000
+#eval ((columnround x) 2 2).to_nat
 
 -- y₁₁
-#eval ((columnround x).nth 11).to_nat
 #eval 0x00000000
+#eval ((columnround x) 2 3).to_nat
 
 -- y₁₂
-#eval ((columnround x).nth 12).to_nat
 #eval 0x40a04001
+#eval ((columnround x) 3 0).to_nat
 
 -- y₁₃
-#eval ((columnround x).nth 13).to_nat
 #eval 0x00000000
+#eval ((columnround x) 3 1).to_nat
 
 -- y₁₄
-#eval ((columnround x).nth 14).to_nat
 #eval 0x00000000
+#eval ((columnround x) 3 2).to_nat
 
 -- y₁₅
-#eval ((columnround x).nth 15).to_nat
 #eval 0x00000000
+#eval ((columnround x) 3 3).to_nat
 
 end example1
 
@@ -619,73 +593,73 @@ def x : vector (bitvec word_len) 16 :=
   subtype.mk [x₀, x₁, x₂, x₃, x₄, x₅, x₆, x₇, x₈, x₉, x₁₀, x₁₁, x₁₂, x₁₃, x₁₄, x₁₅] (by refl)
 
 -- y₀
-#eval ((columnround x).nth 0).to_nat
 #eval 0x8c9d190a
+#eval ((columnround x) 0 0).to_nat
 
 -- y₁
-#eval ((columnround x).nth 1).to_nat
 #eval 0xce8e4c90
+#eval ((columnround x) 0 1).to_nat
 
 -- y₂
-#eval ((columnround x).nth 2).to_nat
 #eval 0x1ef8e9d3
+#eval ((columnround x) 0 2).to_nat
 
 -- y₃
-#eval ((columnround x).nth 3).to_nat
 #eval 0x1326a71a
+#eval ((columnround x) 0 3).to_nat
 
 -- y₄
-#eval ((columnround x).nth 4).to_nat
 #eval 0x90a20123
+#eval ((columnround x) 1 0).to_nat
 
 -- y₅
-#eval ((columnround x).nth 5).to_nat
 #eval 0xead3c4f3
+#eval ((columnround x) 1 1).to_nat
 
 -- y₆
-#eval ((columnround x).nth 6).to_nat
 #eval 0x63a091a0
+#eval ((columnround x) 1 2).to_nat
 
 -- y₇
-#eval ((columnround x).nth 7).to_nat
 #eval 0xf0708d69
+#eval ((columnround x) 1 3).to_nat
 
 -- y₈
-#eval ((columnround x).nth 8).to_nat
 #eval 0x789b010c
+#eval ((columnround x) 2 0).to_nat
 
 -- y₉
-#eval ((columnround x).nth 9).to_nat
 #eval 0xd195a681
+#eval ((columnround x) 2 1).to_nat
 
 -- y₁₀
-#eval ((columnround x).nth 10).to_nat
 #eval 0xeb7d5504
+#eval ((columnround x) 2 2).to_nat
 
 -- y₁₁
-#eval ((columnround x).nth 11).to_nat
 #eval 0xa774135c
+#eval ((columnround x) 2 3).to_nat
 
 -- y₁₂
-#eval ((columnround x).nth 12).to_nat
 #eval 0x481c2027
+#eval ((columnround x) 3 0).to_nat
 
 -- y₁₃
-#eval ((columnround x).nth 13).to_nat
 #eval 0x53a8e4b5
+#eval ((columnround x) 3 1).to_nat
 
 -- y₁₄
-#eval ((columnround x).nth 14).to_nat
 #eval 0x4c1f89c5
+#eval ((columnround x) 3 2).to_nat
 
 -- y₁₅
-#eval ((columnround x).nth 15).to_nat
 #eval 0x3f78c9c8
+#eval ((columnround x) 3 3).to_nat
 
 end example2
 
 
-end rowround
+end columnround
 
 
 namespace doubleround

--- a/src/salsa20/quarterround.lean
+++ b/src/salsa20/quarterround.lean
@@ -8,73 +8,71 @@ open words
 
 namespace quarterround
 
--- z₁ = y₁ ⊕ ((y₀ + y₃) <<< 7)
-def z₁ (y : vector (bitvec word_len) 4) : bitvec word_len := 
-  bitvec.xor (y.nth 1) (rotl (nat_as_bitvec (mod_as_nat (add_bitvecs_as_mod (y.nth 0) (y.nth 3)))) 7)
+-- quarterround returns a vector [a, b ,c, d] where modifications to elements where made.
+-- according to https://en.wikipedia.org/wiki/Salsa20 and the spec.
+def quarterround (y : vector (bitvec word_len) 4) : vector (bitvec word_len) 4 := do
+  -- a = y₀ and then z₀
+  let a := y.nth 0,
+  -- b = y₁ and then z₁
+  let b := y.nth 1,
+  -- c = y₂ and then z₂
+  let c := y.nth 2,
+  -- d = y₃ and then z₃
+  let d := y.nth 3,
 
--- z₂ = y₂ ⊕ ((z₁ + y₀) <<< 9)
-def z₂ (y : vector (bitvec word_len) 4) : bitvec word_len := 
-  bitvec.xor (y.nth 2) (rotl (nat_as_bitvec (mod_as_nat (add_bitvecs_as_mod (z₁ y) (y.nth 0)))) 9)
+  -- z₁ = y₁ ⊕ ((y₀ + y₃) <<< 7)
+  let b := b.xor (rotl (nat_as_bitvec (mod_as_nat (add_bitvecs_as_mod a d))) 7),
+  -- z₂ = y₂ ⊕ ((z₁ + y₀) <<< 9)
+  let c := c.xor (rotl (nat_as_bitvec (mod_as_nat (add_bitvecs_as_mod b a))) 9),
+  -- z₃ = y₃ ⊕ ((z₂ + z₁) <<< 13)
+  let d := d.xor (rotl (nat_as_bitvec (mod_as_nat (add_bitvecs_as_mod c b))) 13),
+  -- z₀ = y₀ ⊕ ((z₃ + z₂) <<< 18)
+  let a := a.xor (rotl (nat_as_bitvec (mod_as_nat (add_bitvecs_as_mod d c))) 18),
 
--- z₃ = y₃ ⊕ ((z₂ + z₁) <<< 13)
-def z₃ (y : vector (bitvec word_len) 4) : bitvec word_len := 
-  bitvec.xor (y.nth 3) (rotl (nat_as_bitvec (mod_as_nat (add_bitvecs_as_mod (z₂ y) (z₁ y)))) 13)
-
--- z₀ = y₀ ⊕ ((z₃ + z₂) <<< 18)
-def z₀ (y : vector (bitvec word_len) 4) : bitvec word_len := 
-  bitvec.xor (y.nth 0) (rotl (nat_as_bitvec (mod_as_nat (add_bitvecs_as_mod (z₃ y) (z₂ y)))) 18)
-
--- quarterround(y = y₀, y₁, y₂, y₃) = (z₀, z₁, z₂, z₃)
-def quarterround (y : vector (bitvec word_len) 4) : vector (bitvec word_len) 4 :=
-    subtype.mk [z₀ y, z₁ y, z₂ y, z₃ y] (by refl)
-
--- quarterround(0, 0, 0, 0) = [0, 0, 0, 0]
-lemma quarterround_zero : 
-  (quarterround (subtype.mk [0, 0, 0, 0] (by refl))).to_list = [0, 0, 0, 0] := rfl
+  subtype.mk [a, b, c, d] (by refl)
 
 -- The whole quarterround function is invertible because individual vector components are invertible.
 -- From z = [z₀, z₁, z₂, z₃] we can get back to [y₀, y₁, y₂, y₃]
-
--- The interesting thing is that it seems we don't need to apply the inverses of rotl and zmod
+-- 
+-- Note: it is interesting that it seems we don't need to apply the inverses of rotl and zmod
 -- addition, instead to get yₓ we just replace zₓ in the original formula and compute. 
+def quarterround_inv (z : vector(bitvec word_len) 4) : vector (bitvec word_len) 4 := do
+  -- a = z₀ and then y₀
+  let a := z.nth 0,
+  -- b = z₁ and then y₁
+  let b := z.nth 1,
+  -- c = z₂ and then y₂
+  let c := z.nth 2,
+  -- d = z₃ and then y₃
+  let d := z.nth 3,
 
--- y₀ = z₀ ⊕ ((z₃ + z₂) <<< 18)
-def y₀ (z : vector (bitvec word_len) 4) : bitvec word_len := 
-  bitvec.xor (z.nth 0) (rotl (nat_as_bitvec (mod_as_nat (add_bitvecs_as_mod (z.nth 3) (z.nth 2)))) 18) 
+  -- y₀ = z₀ ⊕ ((z₃ + z₂) <<< 18)
+  let a := a.xor (rotl (nat_as_bitvec (mod_as_nat (add_bitvecs_as_mod d c))) 18),
+  -- y₃ = z₃ ⊕ ((z₂ + z₁) <<< 13)
+  let d := d.xor (rotl (nat_as_bitvec (mod_as_nat (add_bitvecs_as_mod c b))) 13),
+  -- y₂ = z₂ ⊕ ((z₁ + y₀) <<< 9)
+  let c := c.xor (rotl (nat_as_bitvec (mod_as_nat (add_bitvecs_as_mod b a))) 9),
+  -- y₁ = z₁ ⊕ ((y₀ + y₃) <<< 7)
+  let b := b.xor (rotl (nat_as_bitvec (mod_as_nat (add_bitvecs_as_mod a d))) 7),
 
--- y₃ = z₃ ⊕ ((z₂ + z₁) <<< 13)
-def y₃ (z : vector (bitvec word_len) 4) : bitvec word_len := 
-  bitvec.xor (z.nth 3) (rotl (nat_as_bitvec (mod_as_nat (add_bitvecs_as_mod (z.nth 2) (z.nth 1)))) 13) 
+  subtype.mk [a, b, c, d] (by refl)
 
--- y₂ = z₂ ⊕ ((z₁ + y₀) <<< 9)
-def y₂ (z : vector (bitvec word_len) 4) : bitvec word_len := 
-  bitvec.xor (z.nth 2) (rotl (nat_as_bitvec (mod_as_nat (add_bitvecs_as_mod (z.nth 1) (y₀ z)))) 9) 
+-- 
+axiom quarterround_inv_is_always_inv : ∀ (y : vector(bitvec word_len) 4), y = quarterround_inv (quarterround y)
 
--- y₁ = z₁ ⊕ ((y₀ + y₃) <<< 7)
-def y₁ (z : vector (bitvec word_len) 4) : bitvec word_len := 
-  bitvec.xor (z.nth 1) (rotl (nat_as_bitvec (mod_as_nat (add_bitvecs_as_mod (y₀ z) (y₃ z)))) 7) 
+-- quarterround([0, 0, 0, 0]) = [0, 0, 0, 0]
+lemma quarterround_zero :
+  (quarterround (subtype.mk [0, 0, 0, 0] (by refl))).to_list = [0, 0, 0, 0] := rfl
 
--- The inverse of the quarterround function puts together the above definitions for the 
--- components of y.
-def quarterround_inv (z : vector (bitvec word_len) 4) : vector (bitvec word_len) 4 :=
-  subtype.mk [
-    y₀ z,
-    y₁ z,
-    y₂ z,
-    y₃ z
-  ] (by refl)
-
--- double quarterround is not the inverse
-lemma double_quarterround_not_inverse (y : vector (bitvec word_len) 4) : quarterround (quarterround y) ≠ y :=
+-- The quarteround function is the inverse
+lemma quarterround_inv_is_inv (y : vector(bitvec word_len) 4) : y = quarterround_inv (quarterround y) :=
 begin
-  sorry,
+  rw ← quarterround_inv_is_always_inv,
 end
 
--- quarterround_inv is the inverse
-lemma quarterround_inv_is_inverse (y : vector (bitvec word_len) 4) : y = quarterround_inv (quarterround y) :=
+-- applying quarterround twice is not the inverse
+lemma double_quarteround_is_not_inv (y : vector(bitvec word_len) 4) : y ≠ quarterround (quarterround y) :=
 begin
-  unfold quarterround_inv,
-  unfold quarterround,
   sorry,
 end
 

--- a/src/salsa20/rowround.lean
+++ b/src/salsa20/rowround.lean
@@ -2,69 +2,59 @@
   Section 4 : The rowround function
   http://cr.yp.to/snuffle/spec.pdf
 -/
+import data.matrix.basic
+
 import salsa20.words
 import salsa20.quarterround
+
+open matrix
 
 open words
 open quarterround
 
 namespace rowround
 
--- (z₀, z₁, z₂, z₃) = quarterround(y₀, y₁, y₂, y₃)
-def rowround1 (y₀ y₁ y₂ y₃ : bitvec word_len) : vector (bitvec word_len) 4 := 
-  quarterround (subtype.mk [y₀, y₁, y₂, y₃] (by refl))
+-- Given a vector of 16 words, convert it to a 4x4 matrix.
+def vector_as_matrix (y : vector(bitvec word_len) 16) : matrix (fin 4) (fin 4) (bitvec word_len) :=
+  ![
+    ![(y.nth 0), (y.nth 1), (y.nth 2), (y.nth 3)],
+    ![(y.nth 4), (y.nth 5), (y.nth 6), (y.nth 7)],
+    ![(y.nth 8), (y.nth 9), (y.nth 10), (y.nth 11)],
+    ![(y.nth 12), (y.nth 13), (y.nth 14), (y.nth 15)]
+  ]
 
--- (z₅, z₆, z₇, z₄) = quarterround(y₅, y₆, y₇, y₄)
-def rowround2 (y₅ y₆ y₇ y₄ : bitvec word_len) : vector (bitvec word_len) 4 := 
-  quarterround (subtype.mk [y₅, y₆, y₇, y₄] (by refl))
+-- The rowround function in the matrix form
+def rowround (y : vector(bitvec word_len) 16) : matrix (fin 4) (fin 4) (bitvec word_len) := do
+  let Y := vector_as_matrix y,
 
--- (z₁₀, z₁₁, z₈, z₉) = quarterround(y₁₀, y₁₁, y₈, y₉)
-def rowround3 (y₁₀ y₁₁ y₈ y₉ : bitvec word_len) : vector (bitvec word_len) 4 := 
-  quarterround (subtype.mk [y₁₀, y₁₁, y₈, y₉] (by refl))
+  -- (z₀, z₁, z₂, z₃) = quarterround(y₀, y₁, y₂, y₃)
+  let row1 := quarterround (subtype.mk [(Y 0 0), (Y 0 1), (Y 0 2), (Y 0 3)] (by refl)),
+  -- (z₅, z₆, z₇, z₄) = quarterround(y₅, y₆, y₇, y₄)
+  let row2 := quarterround (subtype.mk [(Y 1 1), (Y 1 2), (Y 1 3), (Y 1 0)] (by refl)),
+  -- (z₁₀, z₁₁, z₈, z₉) = quarterround(y₁₀, y₁₁, y₈, y₉)
+  let row3 := quarterround (subtype.mk [(Y 2 2), (Y 2 3), (Y 2 0), (Y 2 1)] (by refl)),
+  -- quarterround(y₁₅, y₁₂, y₁₃, y₁₄)
+  let row4 := quarterround (subtype.mk [(Y 3 3), (Y 3 0), (Y 3 1), (Y 3 2)] (by refl)),
 
--- (z₁₅, z₁₂, z₁₃, z₁₄) = quarterround(y₁₅, y₁₂, y₁₃, y₁₄)
-def rowround4 (y₁₅ y₁₂ y₁₃ y₁₄ : bitvec word_len) : vector (bitvec word_len) 4 := 
-  quarterround (subtype.mk  [y₁₅, y₁₂, y₁₃, y₁₄] (by refl))
+  let new_matrix := 
+  ![
+    ![(row1.nth 0), (row1.nth 1), (row1.nth 2), (row1.nth 3)],
+    ![(row2.nth 3), (row2.nth 0), (row2.nth 1), (row2.nth 2)],
+    ![(row3.nth 2), (row3.nth 3), (row3.nth 0), (row3.nth 1)],
+    ![(row4.nth 1), (row4.nth 2), (row4.nth 3), (row4.nth 0)]
+  ],
 
--- If y = (y₀, y₁, y₂, y₃, ... , y₁₅) then 
--- rowround(y) = (z₀, z₁, z₂, z₃, ... , z₁₅) where
--- (z₀, z₁, z₂, z₃) = quarterround(y₀, y₁, y₂, y₃)
--- (z₅, z₆, z₇, z₄) = quarterround(y₅, y₆, y₇, y₄)
--- (z₁₀, z₁₁, z₈, z₉) = quarterround(y₁₀, y₁₁, y₈, y₉)
--- (z₁₅, z₁₂, z₁₃, z₁₄) = quarterround(y₁₅, y₁₂, y₁₃, y₁₄)
-def rowround (y : vector(bitvec word_len) 16) : vector (bitvec word_len) 16 :=
-  do
-    let r1 := rowround1 (y.nth 0) (y.nth 1) (y.nth 2) (y.nth 3),
-    let r2 := rowround2 (y.nth 5) (y.nth 6) (y.nth 7) (y.nth 4),
-    let r3 := rowround3 (y.nth 10) (y.nth 11) (y.nth 8) (y.nth 9),
-    let r4 := rowround4 (y.nth 15) (y.nth 12) (y.nth 13) (y.nth 14),
+  new_matrix
 
-    let z₀ := r1.head,
-    let z₁ := r1.nth 1,
-    let z₂ := r1.nth 2,
-    let z₃ := r1.nth 3,
-
-    let z₅ := r2.head,
-    let z₆ := r2.nth 1,
-    let z₇ := r2.nth 2,
-    let z₄ := r2.nth 3,
-
-    let z₁₀ := r3.head,
-    let z₁₁ := r3.nth 1,
-    let z₈ := r3.nth 2,
-    let z₉ := r3.nth 3,
-
-    let z₁₅ := r4.head,
-    let z₁₂ := r4.nth 1,
-    let z₁₃ := r4.nth 2,
-    let z₁₄ := r4.nth 3,
-
-    subtype.mk [z₀, z₁, z₂, z₃, z₄, z₅, z₆, z₇, z₈, z₉, z₁₀, z₁₁, z₁₂, z₁₃, z₁₄, z₁₅] (by refl)
-
-lemma rowround_zero : 
+-- The rowround of input all zeros is a matrix where its componenets are all zeros.
+lemma rowround_zero :
   rowround (subtype.mk [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] (by refl)) = 
-    subtype.mk  [0, 0, 0 ,0, 0, 0, 0, 0, 0, 0, 0, 0 ,0 ,0, 0, 0] (by refl) := rfl
+    ![
+     ![0, 0, 0 ,0],
+     ![0, 0, 0 ,0],
+     ![0, 0, 0 ,0],
+     ![0, 0, 0 ,0]
+    ] := rfl
 
--- TODO: matrix form
 
 end rowround


### PR DESCRIPTION
Removing some code form this functions as it can be a lot simpler. Looking for the most simpler code we can have so it should be easier to create proofs.